### PR TITLE
ヘルスチェック用のルーティングを別ファイルで管理する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+ENABLE_ROUTES=api,web
+
 LOG_CHANNEL=stack
 LOG_LEVEL=debug
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -46,6 +46,9 @@ class RouteServiceProvider extends ServiceProvider
             Route::middleware('web')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/web.php'));
+
+            Route::namespace($this->namespace)
+                ->group(base_path('routes/health-check.php'));
         });
     }
 

--- a/routes/health-check.php
+++ b/routes/health-check.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/health-check', function () {
+    return response()->json(['status' => 'ok']);
+});


### PR DESCRIPTION
```console
$ curl -i http://localhost/health-check
HTTP/1.1 200 OK
Date: Tue, 07 Dec 2021 15:41:59 GMT
Server: Apache
Cache-Control: no-cache, private
X-Robots-Tag: noindex, nofollow
Content-Length: 15
Content-Type: application/json

{"status":"ok"}
```